### PR TITLE
Adding the ability to buy a domain or address with other cryptocurrencies using the FIO Registration website.

### DIFF
--- a/src/components/Addresses.js
+++ b/src/components/Addresses.js
@@ -91,7 +91,7 @@ export default class Addresses extends Component {
             onSuccess={this.onSuccess}
             ual={this.props.ual}
           />
-          <a class="ui blue right floated button" href={ 'https://reg.fioprotocol.io/ref/fioreghelper?publicKey=' + this.state.owner_fio_public_key }><i aria-hidden="true" class="dollar icon"></i>Buy FIO Address</a>
+          <a class="ui blue right floated button" href={ 'https://reg.fioprotocol.io/address/fioreghelper?publicKey=' + this.state.owner_fio_public_key }><i aria-hidden="true" class="dollar icon"></i>Buy FIO Address</a>
         </Segment>
         {(!addresses.length)
           ? (

--- a/src/components/Addresses.js
+++ b/src/components/Addresses.js
@@ -16,6 +16,7 @@ import RenewAddress from './Modals/RenewAddress';
 export default class Addresses extends Component {
   state = {
     addresses: [],
+    owner_fio_public_key: '',
   }
   componentDidMount() {
     const { ual: { activeUser } } = this.props;
@@ -46,12 +47,15 @@ export default class Addresses extends Component {
         owner_account: accountName
       };
       const [, others] = partition(this.state.addresses, partitionQuery);
-      this.setState({
-        addresses: [
-          ...others,
-          ...results.rows
-        ]
-      })
+      rpc.get_account(accountName).then((account) => {
+        this.setState({
+          addresses: [
+            ...others,
+            ...results.rows
+          ],
+          owner_fio_public_key: account.permissions.filter((p) => p.perm_name === 'owner')[0].required_auth.keys[0].key
+        })
+      });
     })
   }
   render() {
@@ -87,6 +91,7 @@ export default class Addresses extends Component {
             onSuccess={this.onSuccess}
             ual={this.props.ual}
           />
+          <a class="ui blue right floated button" href={ 'https://reg.fioprotocol.io/ref/fioreghelper?publicKey=' + this.state.owner_fio_public_key }><i aria-hidden="true" class="dollar icon"></i>Buy FIO Address</a>
         </Segment>
         {(!addresses.length)
           ? (

--- a/src/components/Domains.js
+++ b/src/components/Domains.js
@@ -19,6 +19,7 @@ export default class Domains extends Component {
   state = {
     addresses: [],
     domains: [],
+    owner_fio_public_key: '',
   }
   componentDidMount() {
     const { ual: { activeUser } } = this.props;
@@ -51,7 +52,12 @@ export default class Domains extends Component {
       if (results.rows.length) {
         results.rows.map(this.getAddresses);
       }
-    })
+    });
+    rpc.get_account(accountName).then((account) => {
+      this.setState({
+        owner_fio_public_key: account.permissions.filter((p) => p.perm_name === 'owner')[0].required_auth.keys[0].key
+      })
+    });
   }
   getAddresses = (domain) => {
     const { ual: { activeUser: { rpc } } } = this.props;
@@ -101,6 +107,7 @@ export default class Domains extends Component {
             onSuccess={this.onSuccess}
             ual={this.props.ual}
           />
+          <a class="ui blue right floated button" href={ 'https://reg.fioprotocol.io/domain/fioreghelper?publicKey=' + this.state.owner_fio_public_key }><i aria-hidden="true" class="dollar icon"></i>Buy FIO Domain</a>
         </Segment>
         {(!domains.length)
           ? (

--- a/src/components/Modals/TransferDomain.js
+++ b/src/components/Modals/TransferDomain.js
@@ -201,7 +201,7 @@ export default class TransferDomain extends Component {
               error={errors.length}
               onSubmit={this.transact}
             >
-              {Object.keys(fields).filter(n => n != "disabled").map((field) => {
+              {Object.keys(fields).filter(n => n !== "disabled").map((field) => {
                 const [error] = errors.filter((e) => e.name === field)
                 if (field === 'tpid') return false
                 return (


### PR DESCRIPTION
Adds a buy address:
![image](https://user-images.githubusercontent.com/344748/99109129-b7a52700-25be-11eb-9890-4ca82c64751c.png)
Adds a buy domain:
![image](https://user-images.githubusercontent.com/344748/99109164-c5f34300-25be-11eb-97d4-3f767a986617.png)

There may be better ways to get the logged in user key, but I just copied what I saw used in other places in the code.

Future enhancement opportunities: use a pop up window instead and on window close, refresh the page.